### PR TITLE
[ADD] K0000k 3주차

### DIFF
--- a/algorithms/tree/k0000k/Bj11725.java
+++ b/algorithms/tree/k0000k/Bj11725.java
@@ -1,0 +1,51 @@
+package tree.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    int parent = 0;
+    ArrayList<Integer> linkedNode = new ArrayList<>();
+    ArrayList<Integer> child = new ArrayList<>();
+}
+
+public class Bj11725 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static HashMap<Integer, Node> tree = new HashMap<>();
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        init(n);
+        for (int i = 0; i < n - 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            tree.get(a).linkedNode.add(b);
+            tree.get(b).linkedNode.add(a);
+        }
+
+        findParent(1);
+
+        for (int i = 2; i < n + 1; i++) {
+            System.out.println(tree.get(i).parent);
+        }
+    }
+
+    private static void findParent(int n) {
+        Node parentNode = tree.get(n);
+        for (Integer nodeIdx : parentNode.linkedNode) {
+            if (nodeIdx != parentNode.parent) {
+                Node childNode = tree.get(nodeIdx);
+                childNode.parent = n;
+                findParent(nodeIdx);
+            }
+        }
+    }
+
+    private static void init(int n) {
+        for (int i = 1; i < n + 1; i++) {
+            tree.put(i, new Node());
+        }
+    }
+}

--- a/algorithms/tree/k0000k/Bj1991.java
+++ b/algorithms/tree/k0000k/Bj1991.java
@@ -1,0 +1,85 @@
+package tree.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    String name = "";
+    String[] child;
+
+    public Node(String name, String[] arr) {
+        this.name = name;
+        this.child = arr;
+    }
+}
+
+public class Bj1991 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static HashMap<String, Node> tree = new HashMap<>();
+    public static boolean[] preorder;
+    public static boolean[] inorder;
+    public static boolean[] postorder;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            String node = st.nextToken();
+            String left = st.nextToken();
+            String right = st.nextToken();
+            tree.put(node, new Node(node, new String[]{left, right}));
+        }
+
+        preorder = new boolean[n + 1];
+        preorder("A");
+        System.out.println();
+
+        inorder = new boolean[n + 1];
+        inorder("A");
+        System.out.println();
+
+        postorder = new boolean[n + 1];
+        postorder("A");
+    }
+
+    // 루트 - 왼쪽 - 오른쪽
+    private static void preorder(String nodeIdx) {
+        Node node = tree.get(nodeIdx);
+        System.out.print(node.name);
+        for (String str : node.child) {
+            if (str.equals(".")) {
+                continue;
+            }
+            preorder(str);
+        }
+    }
+
+    // 왼쪽 - 루트 - 오른쪽
+    private static void inorder(String nodeIdx) {
+        Node node = tree.get(nodeIdx);
+        String left = node.child[0];
+        String right = node.child[1];
+        if (!left.equals(".")) {
+            inorder(left);
+        }
+        System.out.print(nodeIdx);
+        if (!right.equals(".")) {
+            inorder(right);
+        }
+    }
+
+    // 왼쪽 - 오른쪽 - 루트
+    private static void postorder(String nodeIdx) {
+        Node node = tree.get(nodeIdx);
+        String left = node.child[0];
+        String right = node.child[1];
+        if (!left.equals(".")) {
+            postorder(left);
+        }
+        if (!right.equals(".")) {
+            postorder(right);
+        }
+        System.out.print(nodeIdx);
+    }
+}

--- a/algorithms/tree/k0000k/Bj2250.java
+++ b/algorithms/tree/k0000k/Bj2250.java
@@ -1,0 +1,123 @@
+package tree.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    int num;
+    int leftIdx;
+    int rightIdx;
+    int location;
+    int level;
+
+    public Node(int num, int leftIdx, int rightIdx) {
+        this.num = num;
+        this.leftIdx = leftIdx;
+        this.rightIdx = rightIdx;
+    }
+}
+
+public class Bj2250 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static Node[] tree;
+    public static ArrayList<ArrayList<Integer>> levels = new ArrayList<>();
+    public static int[] parent;
+    public static int counter = 1;
+
+    public static void main(String[] args) throws IOException {
+        init(); // 입력, 자료구조 초기화
+
+        int rootIdx = findRoot(); // 트리의 루트 찾기
+        findLocation(rootIdx); // 각 노드의 열 번호 찾기
+        findLevel(rootIdx); // 각 노드의 레벨 찾기
+
+        // 최대길이 구하기
+        int maxLevel = 1;
+        int maxWidth = 0;
+        for (int i = 1; i < levels.size(); i++) {
+            ArrayList<Integer> list = levels.get(i);
+            if (list.isEmpty()) {
+                break;
+            }
+            // BFS 수행 시에 왼쪽 노드부터 리스트에 저장했으므로, 0번과 가장 끝 인덱스의 값이 길이의 최대
+            int leftIdx = list.get(0);
+            int rightIdx = list.get(list.size() - 1);
+            int width = tree[rightIdx].location - tree[leftIdx].location + 1;
+            if (width > maxWidth) {
+                maxWidth = width;
+                maxLevel = i;
+            }
+        }
+
+        System.out.println(maxLevel + " " + maxWidth);
+    }
+
+    // 입력 처리, 자료구조 초기화, parent 배열 업데이트
+    private static void init() throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        tree = new Node[n + 1];
+        parent = new int[n + 1];
+        for (int i = 0; i < n + 1; i++) {
+            levels.add(new ArrayList<>());
+        }
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int idx = Integer.parseInt(st.nextToken());
+            int left = Integer.parseInt(st.nextToken());
+            int right = Integer.parseInt(st.nextToken());
+            tree[idx] = new Node(idx, left, right);
+            if (left != -1) {
+                parent[left] = idx;
+            }
+            if (right != -1) {
+                parent[right] = idx;
+            }
+        }
+    }
+
+    // 부모 노드가 없으면 root 노드
+    private static int findRoot() {
+        for (int i = 1; i < parent.length; i++) {
+            if (parent[i] == 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    // 중위 순회로 노드의 열 번호를 계산
+    private static void findLocation(int rootIdx) {
+        Node node = tree[rootIdx];
+        if (node.leftIdx != -1) {
+            findLocation(node.leftIdx);
+        }
+        node.location = counter++;
+        if (node.rightIdx != -1) {
+            findLocation(node.rightIdx);
+        }
+    }
+
+    // BFS로 모든 노드의 레벨을 계산
+    private static void findLevel(int rootIdx) {
+        ArrayDeque<Node> queue = new ArrayDeque<>();
+        tree[rootIdx].level = 1;
+        levels.get(1).add(rootIdx);
+        queue.add(tree[rootIdx]);
+        while (!queue.isEmpty()) {
+            Node node = queue.pollFirst();
+            if (node.leftIdx != -1) {
+                Node leftNode = tree[node.leftIdx];
+                leftNode.level = node.level + 1;
+                levels.get(leftNode.level).add(node.leftIdx);
+                queue.add(leftNode);
+            }
+            if (node.rightIdx != -1) {
+                Node rightNode = tree[node.rightIdx];
+                rightNode.level = node.level + 1;
+                levels.get(rightNode.level).add(node.rightIdx);
+                queue.add(rightNode);
+            }
+        }
+    }
+}

--- a/algorithms/tree/k0000k/Bj5639.java
+++ b/algorithms/tree/k0000k/Bj5639.java
@@ -1,0 +1,76 @@
+package tree.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    int val;
+    Node left;
+    Node right;
+
+    public Node(int val) {
+        this.val = val;
+    }
+}
+
+class Tree {
+    Node root;
+
+    public Tree(Node root) {
+        this.root = root;
+    }
+
+    public void addNode(Node node, int value) {
+        if (value < node.val) {
+            if (node.left == null) {
+                node.left = new Node(value);
+                return;
+            }
+            addNode(node.left, value);
+        }
+        else {
+            if (node.right == null) {
+                node.right = new Node(value);
+                return;
+            }
+            addNode(node.right, value);
+        }
+    }
+}
+
+public class Bj5639 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static ArrayList<Integer> preorders = new ArrayList<>();
+    public static Node root;
+
+    public static void main(String[] args) throws IOException {
+        while (true) {
+            String input = br.readLine();
+            if (input == null) {
+                break;
+            }
+            preorders.add(Integer.parseInt(input));
+        }
+
+        root = new Node(preorders.get(0));
+        Tree tree = new Tree(root);
+        for (int i = 1; i < preorders.size(); i++) {
+            tree.addNode(root, preorders.get(i));
+        }
+
+        postorder(root);
+    }
+
+    private static void postorder(Node node) {
+        if (node.left != null) {
+            postorder(node.left);
+        }
+
+        if (node.right != null) {
+            postorder(node.right);
+        }
+
+        System.out.println(node.val);
+    }
+}

--- a/algorithms/tree/k0000k/Bj9934.java
+++ b/algorithms/tree/k0000k/Bj9934.java
@@ -1,0 +1,68 @@
+package tree.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj9934 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static ArrayList<Integer> order = new ArrayList<>();
+    public static boolean[] visited;
+    public static ArrayList<ArrayList<Integer>> levels = new ArrayList<>();
+    public static int buildingIdx = 0;
+
+    public static void main(String[] args) throws IOException {
+        int maxLevel = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        while (st.hasMoreTokens()) {
+            order.add(Integer.parseInt(st.nextToken()));
+        }
+
+        init(maxLevel);
+        traverse(1);
+
+        for (int i = 1; i < levels.size(); i++) {
+            ArrayList<Integer> list = levels.get(i);
+            for (Integer num : list) {
+                System.out.print(num + " ");
+            }
+            System.out.println();
+        }
+    }
+
+    private static void traverse(int nodeIdx) {
+        int leftIdx = nodeIdx * 2;
+        int rightIdx = leftIdx + 1;
+
+        // 왼쪽 노드
+        if (leftIdx < visited.length && !visited[leftIdx]) {
+            traverse(leftIdx);
+        }
+
+        // 현재 노드
+        visited[nodeIdx] = true;
+        calcLevel(nodeIdx);
+
+        // 오른쪽 노드
+        if (rightIdx < visited.length && !visited[rightIdx]) {
+            traverse(rightIdx);
+        }
+    }
+
+    private static void calcLevel(int nodeIdx) {
+        int level = 1;
+        int firstNodeIdx = 1;
+        while (nodeIdx >= firstNodeIdx * 2) {
+            firstNodeIdx *= 2;
+            level += 1;
+        }
+        levels.get(level).add(order.get(buildingIdx++));
+    }
+
+    private static void init(int maxLevel) {
+        visited = new boolean[order.size() + 1];
+        for (int i = 0; i < maxLevel + 1; i++) {
+            levels.add(new ArrayList<>());
+        }
+    }
+}


### PR DESCRIPTION
**11725 트리의 부모 찾기 (실버 2)**
 이전에 파이썬으로 맞췄던 문제입니다. 노드의 갯수가 최대 10만개라서, 전체 순회를 한 번 돌라는 방식으로 해결할 수 있을 것이라고 봤습니다. 모든 노드에 연결된 간선을 저장해놓고, 루트부터 순회하면서 child 노드를 찾았습니다.

**1991 트리 순회 (실버1)**
 이 문제도 파이썬으로 맞췄던 문제입니다. 전위, 중위, 후위 순회를 진행하면서 중복되는 코드들이 있는데.. 흐음... 좀 더 메소드 추출을 하고싶다는 아쉬움이 남습니다.

**9934 완전 이진 트리 (실버1)**
노드의 인덱스와 건물 번호를 따로 관리 해야해서 조금 복잡했던 문제입니다... 지금보니 지난 피드백때 이야기 들었던 'StringBuilder를 써서 출력할걸 ㅠ' 하는 생각이 듭니다.

**5639 이진 검색 트리 (골드4)**
노드의 수가 10000 이하입니다. 복잡하게 생각할 것 없이 트리를 만들어준 다음에 후위 순회 돌리면 충분할 것이라고 생각했습니다. 여기까지는 좋았으나... 구현 중에 재귀를 잘못짜서 한참 고생을 했었네요ㅜㅜ 어쨌든 풀었습니다!

**2250 트리의 높이와 너비 (골드2)**
**기본기가 정말정말 중요하다는 것을 깨달은 문제입니다.** 처음에 굉장히 어려운(?) 방법으로 접근하고 있었습니다. 모든 노드의 왼쪽과 오른쪽 서브트리의 노드 갯수를 센 다음에 열 번호를 계산하자! 이런 생각이였는데... 노드가 루트의 왼쪽에 있는지, 오른쪽에 있는지에 따라 경우가 달라지게 되니 너무 복잡해져서 다른 방법을 탐색해보았습니다. 잘 보니 중위 순회로 탐색하는 순서가 열 번호와 동일하다는 사실을 알게 되었습니다. 그래서 먼저 루트를 찾고, 루트에서 시작하는 중위 순회로 모든 노드의 열 번호를 계산하고, BFS로 모든 노드의 레벨을 계산한 뒤에 최댓값을 계산할 수 있었습니다.