### PR TITLE
[ADD] GainLee 6주차

### DIFF
--- a/algorithms/dynamic_programming_2/GainLee/Boj_12865.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_12865.java
@@ -1,0 +1,4 @@
+package dynamic_programming_2.GainLee;
+
+public class Boj_12865 {
+}

--- a/algorithms/dynamic_programming_2/GainLee/Boj_12865.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_12865.java
@@ -1,4 +1,32 @@
 package dynamic_programming_2.GainLee;
 
+import java.io.*;
+import java.util.*;
+
 public class Boj_12865 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, k;
+
+    public static void main(String[] args) throws IOException{
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken()); // 물건의 개수
+        k = Integer.parseInt(st.nextToken()); // 최대 무게
+        int[][] things = new int[n+1][2];
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int w = Integer.parseInt(st.nextToken()); // 물건 무게
+            int v = Integer.parseInt(st.nextToken()); // 물건 가치
+            things[i][0] = w;
+            things[i][1] = v;
+        }
+
+        int[] dp = new int[k+1];
+        for (int i = 1; i <= n; i++) {
+            for (int j = k; j-things[i][0] >= 0; j--) {
+                dp[j] = Math.max(dp[j], dp[j-things[i][0]] + things[i][1]);
+            } // for
+        } // for
+        System.out.println(dp[k]);
+    }
 }

--- a/algorithms/dynamic_programming_2/GainLee/Boj_15724.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_15724.java
@@ -1,0 +1,41 @@
+package dynamic_programming_2.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_15724 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static StringBuilder sb;
+    static int[][] map, prefix;
+    public static void main(String[] args) throws IOException{
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        map = new int[n+1][m+1];
+        prefix = new int[n+1][m+1];
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                prefix[i][j] = map[i][j] + prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1];
+            }
+        } // for
+        sb = new StringBuilder("");
+        int k = Integer.parseInt(br.readLine());
+        for (int i = 0; i < k; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x1 = Integer.parseInt(st.nextToken());
+            int y1 = Integer.parseInt(st.nextToken());
+            int x2 = Integer.parseInt(st.nextToken());
+            int y2 = Integer.parseInt(st.nextToken());
+
+            int sum = prefix[x2][y2] - prefix[x1-1][y2] - prefix[x2][y1-1] + prefix[x1-1][y1-1];
+            sb.append(sum).append("\n");
+        } //
+        System.out.print(sb);
+        br.close();
+    } // main
+}

--- a/algorithms/dynamic_programming_2/GainLee/Boj_1695.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_1695.java
@@ -1,0 +1,4 @@
+package dynamic_programming_2.GainLee;
+
+public class Boj_1695 {
+}

--- a/algorithms/dynamic_programming_2/GainLee/Boj_1695.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_1695.java
@@ -1,4 +1,46 @@
 package dynamic_programming_2.GainLee;
 
+import java.io.*;
+import java.util.*;
+
 public class Boj_1695 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+        int[] arr = new int[n];
+
+        // 입력받기
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        } // for
+
+        int dp[][] = new int[n+1][n+1];
+
+        for (int i = 0; i < n-1; i++) {
+            dp[i][i+1] = (arr[i] == arr[i+1]) ? 0 : 1;
+        }
+        
+        for (int len = 3; len <= n; len++) {
+            for (int i = 0; i <= n - len; i++) {
+                int j = i + len - 1;
+                // 만약 시작점과 끝점이 같다면 이전 거 갖고 오기
+                if (arr[i] == arr[j]) {
+                    dp[i][j] = dp[i+1][j-1];
+                } else {
+                    dp[i][j] = Math.min(dp[i+1][j], dp[i][j-1])+ 1;
+                }
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                System.out.print(dp[i][j] + " ");
+            }
+            System.out.println();
+        }
+        System.out.println(dp[0][n-1]);
+    }
 }

--- a/algorithms/dynamic_programming_2/GainLee/Boj_17485.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_17485.java
@@ -1,4 +1,58 @@
 package dynamic_programming_2.GainLee;
 
+import java.io.*;
+import java.util.*;
+
 public class Boj_17485 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int[][] map = new int[n+1][m+1];
+
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int[][][] dp = new int[n+2][m+2][3];
+
+        for (int i = 2; i <= n ; i++) {
+            for (int j = 1; j <= m; j++) {
+                Arrays.fill(dp[i][j], 1000001);
+            }
+        }
+
+        for (int j = 1; j <= m; j++) {
+            dp[1][j][0] = map[1][j]; // 왼쪽 위에서 이동
+            dp[1][j][1] = map[1][j]; // 위에서 이동
+            dp[1][j][2] = map[1][j]; // 오른쪽 위에서 이동
+        }
+
+        for (int i = 2; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                if (j - 1 >= 1) {
+                    dp[i][j][0] = Math.min(dp[i-1][j-1][1], dp[i-1][j-1][2]) + map[i][j];
+                }
+                dp[i][j][1] = Math.min(dp[i-1][j][2], dp[i-1][j][0]) + map[i][j];
+
+                if (j + 1 <= m) {
+                    dp[i][j][2] = Math.min(dp[i-1][j+1][0], dp[i-1][j+1][1]) + map[i][j];
+                }
+            }
+        }
+
+        // 출력
+        int res = 1000001;
+        for (int j = 1; j  <= m; j++) {
+            res = Math.min(res, Math.min(dp[n][j][0], Math.min(dp[n][j][1], dp[n][j][2])));
+        }
+        System.out.println(res);
+
+    } // main
 }

--- a/algorithms/dynamic_programming_2/GainLee/Boj_17485.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_17485.java
@@ -1,0 +1,4 @@
+package dynamic_programming_2.GainLee;
+
+public class Boj_17485 {
+}

--- a/algorithms/dynamic_programming_2/GainLee/Boj_2631.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_2631.java
@@ -1,0 +1,4 @@
+package dynamic_programming_2.GainLee;
+
+public class Boj_2631 {
+}

--- a/algorithms/dynamic_programming_2/GainLee/Boj_2631.java
+++ b/algorithms/dynamic_programming_2/GainLee/Boj_2631.java
@@ -1,4 +1,43 @@
 package dynamic_programming_2.GainLee;
 
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class Boj_2631 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException{
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n+1];
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        List<Integer> lis = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            int num = arr[i];
+            if (lis.isEmpty() || lis.get(lis.size() - 1) < num) {
+                lis.add(num);
+            } else {
+                int left = 0;
+                int right = lis.size();
+
+                while (left < right) {
+                    int mid = (left + right) / 2;
+
+                    if (lis.get(mid) < num) {
+                        left = mid + 1;
+                    } else {
+                        right =  mid;
+                    }
+                } // while
+                lis.set(left, num);
+            } // if-else
+
+        }
+
+        System.out.println(n-lis.size());
+    } // main
 }


### PR DESCRIPTION
✔️ 15724 주지수 🔗  [https://www.acmicpc.net/problem/15724](url)
DP 가 아닌 누적합으로 풀었습니다!
처음에 시도했을때는 이중 for 문을 사용해 사람수를 더했습니다.

// 사람 수 더하기
int sum = 0;
    for (int j = x1-1; j <= x2 - x1 ; j++) {
        for (int l = y1-1; l <= y2 - y1; l++) {
            sum += map.get(j)[l];
        }
    }

이렇게 작성하니 시간복잡도가 O(n^2)이 되고, 시간초과가 발생하더라구요.
시간을 줄이기 위해 사용한 방법이 누적합입니다. 시간복잡도는 O(1)이 됩니다. :)

---

✔️ 17485 진우의 달 여행 🔗  [https://www.acmicpc.net/problem/17485](url)
 정말 고민 많이 했던 문제입니다! 이전에 풀었던 계단오르기 문제와 풀이 방식이 비슷할 것이라고 생각하고 점화식을 세웠습니다.
 2차원 배열의 dp를 가지고 모든 방향에 대해서 갱신을 해주다보니, 문제의 조건인 **같은 방향이 연속할 수 없다**를 위반하는 경우가 발생했습니다. 그래서 방향을 저장하기 위해 3차원 배열 dp를 사용했습니다. 난생 처음 해보는 3차원 dp라 초반엔 뚝딱거렸습니다만, 3차원 DP라고 쫄거 하나도 없더라고요!?! 그냥 조건만 잘 처리해주면 되는 거였습니다 ㅎㅎ
 마지막에 결과값을 갱신해주는 부분에서 기존의 res의 값과 min 값을 비교해 더 작은 값을 res 값으로 갱신하는 코드를 작성하지 않아서 또 시간을 많이 잡아먹었습니다.

---

✔️ 2631 줄세우기  [https://www.acmicpc.net/problem/2631](url)
 팰린드롬 만들기(1695) 문제와 비슷하게 케이스를 쪼개면서 풀이해야할 것이라고 생각했지만, 완전 다르게 풀이한 문제였습니다.
이 문제는 LIS(Longest Increasing Subsequence)를 이용해 풀었습니다.  최장 증가 부분 수열을 찾고, 이 학생들을 제외한 학생들을 움직입니다. 
 즉, 최소 이동 수 는 n(학생수) - LIS.length(최장 증가 부분 수열의 길이) 가 됩니다. LIS 구현 부분은 박상윤님의 블로그를 참고해 작성했습니다.

---

✔️ 1695 팰린드롬 만들기 [https://www.acmicpc.net/problem/1695](url)
이 문제는 박상윤님의 도움을 받아서 해결했습니다. 
문자열의 시작점과 끝점에 따른 값을 저장하기 위해 dp는 2차원 배열로 초기화 합니다. dp[a][b]에서 a는 시작점, b는 끝점을 의미합니다.
우선, 문자열의 길이가 1인 경우 (a와 b가 같은 경우)는 0입니다. 이미 팰린드롬이므로, 더이상 추가할 수가 없기 때문입니다.
문자열의 길이가 2인 경우는, 팰린드롬인 경우와 아닌 경우로 나눠 값을 저장합니다. 3항 연산자를 사용해 가독성 높게 작성했습니다.

문자열의 길이가 3이상인 경우는, 만약 시작점과 끝점의 값이 같다면 시작과 끝점을 제외한 문자열의 dp 값을 가져와 dp 배열의 값을 갱신합니다.
만약, 시작점과 끝점의 문자가 다르다면, 시작점부터 끝점하나전까지, 시작점 하나 뒤부터 끝점까지의 dp값 중 최소값에 1을 더한 값으로 갱신합니다.