### PR TITLE
[ADD] GainLee 8주차

### DIFF
--- a/algorithms/implementation/GainLee/Boj_14719_2.java
+++ b/algorithms/implementation/GainLee/Boj_14719_2.java
@@ -1,0 +1,54 @@
+package implementation.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_14719_2 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int w;
+    static int[] blocks;
+
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        int h = Integer.parseInt(st.nextToken());
+        w = Integer.parseInt(st.nextToken());
+        blocks = new int[w+1];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= w; i++) {
+            blocks[i] = Integer.parseInt(st.nextToken());
+        } // for - 입력
+
+
+        int start = 1;
+        int end = w;
+        int sum = 0;
+
+        // 양쪽이 막혀있을 때까지 start, end 옮기기
+        while (blocks[start] == 0 || blocks[end] == 0) {
+            if (blocks[start] == 0) start++;
+            if (blocks[end] == 0) end--;
+            if (start >= end) break;
+        }
+
+        int start_max = blocks[start];
+        int end_max = blocks[end];
+
+        while (start < end){
+            // start위치와 end위치의 높이를 비교하고, 낮은 쪽을 이동하면서 차이를 더한다.
+            if (start_max <= end_max) {
+                start++;
+                start_max = Math.max(blocks[start], start_max);
+                sum += start_max - blocks[start];
+            } else {
+                end--;
+                end_max = Math.max(blocks[end], end_max);
+                sum += end_max - blocks[end];
+            }
+        } // while
+
+        System.out.println(sum);
+    } // main
+}

--- a/algorithms/implementation/GainLee/Boj_16926.java
+++ b/algorithms/implementation/GainLee/Boj_16926.java
@@ -1,0 +1,4 @@
+package implementation.GainLee;
+
+public class Boj_16926 {
+}

--- a/algorithms/implementation/GainLee/Boj_16926.java
+++ b/algorithms/implementation/GainLee/Boj_16926.java
@@ -1,4 +1,71 @@
 package implementation.GainLee;
+import java.io.*;
+import java.util.*;
+
+import java.io.*;
+import java.util.*;
 
 public class Boj_16926 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int r = Integer.parseInt(st.nextToken());
+        int[][] map = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int layers = Math.min(n, m) / 2;
+        for (int rotation = 0; rotation < r; rotation++) {
+            for (int layer = 0; layer < layers; layer++) {
+                int top = layer;
+                int bottom = n - 1 - layer;
+                int left = layer;
+                int right = m - 1 - layer;
+
+                int temp = map[top][left];
+
+                // 윗변 왼쪽으로 이동
+                for (int j = left; j < right; j++) {
+                    map[top][j] = map[top][j + 1];
+                }
+
+                // 오른쪽 변 위로 이동
+                for (int i = top; i < bottom; i++) {
+                    map[i][right] = map[i + 1][right];
+                }
+
+                // 아랫변 오른쪽으로 이동
+                for (int j = right; j > left; j--) {
+                    map[bottom][j] = map[bottom][j - 1];
+                }
+
+                // 왼쪽 변 아래로 이동
+                for (int i = bottom; i > top + 1; i--) {
+                    map[i][left] = map[i - 1][left];
+                }
+
+                map[top + 1][left] = temp;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                sb.append(map[i][j]).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+
+        br.close();
+    }
 }

--- a/algorithms/implementation/GainLee/Boj_17276.java
+++ b/algorithms/implementation/GainLee/Boj_17276.java
@@ -1,0 +1,64 @@
+package implementation.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_17276 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++) {
+            st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+            int[][] map = new int[n+1][n+1];
+            for (int i = 1; i <= n; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 1; j <= n; j++) {
+                    map[i][j] = Integer.parseInt(st.nextToken());
+                }
+            } // for - map 입력
+
+            d = ((d % 360) + 360) % 360;
+
+            for (int q = d; q > 0; q -= 45) {
+                int[][] new_map = new int[n+1][n+1];
+                for (int i = 1; i <= n; i++) {
+                    for (int j = 1; j <= n; j++) {
+                        // 1. 주 대각선 이동
+                        if (i == j) {
+                            new_map[i][(n+1)/2] = map[i][j];
+                        }
+                        // 2. 가운데 열 이동
+                        else if  (j == (n+1)/2) {
+                            new_map[i][n-i+1] = map[i][j];
+                        }
+                        // 3. 부대각선 이동
+                        else if ( i == n-j+1 ) {
+                            new_map[(n+1)/2][j] = map[i][j];
+                        }
+                        // 4. 가운데 행 이동
+                        else if (i == (n+1)/2){
+                            new_map[j][j] = map[i][j];
+                        }
+                        else {
+                            new_map[i][j] = map[i][j];
+                        }
+                    }
+                } // for - map 이동
+                map= new_map;
+            }
+            // 출력
+            for (int i = 1; i <= n; i++) {
+                for (int j = 1; j <= n; j++) {
+                    System.out.print(map[i][j] + " ");
+                }
+                System.out.println();
+            }
+
+        } // for - t
+        br.close();
+    } // main
+}

--- a/algorithms/implementation/GainLee/Boj_22856.java
+++ b/algorithms/implementation/GainLee/Boj_22856.java
@@ -1,0 +1,68 @@
+package implementation.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_22856 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static Map<Integer, Node> tree = new HashMap<>();
+    static int n;
+    static int cnt = 0;
+    static int[] rightmost = new int[n+1];
+
+    static class Node {
+        int root;
+        Node left, right;
+        Node (int root) {
+            this.root = root;
+        }
+    } // class - Node
+
+    static void likeInorder (Node node) {
+
+        if (node == null) {
+            return;
+        }
+        if (node.left != null) {
+            likeInorder(node.left);
+            cnt += 2;
+        }
+        if (node.right != null) {
+            likeInorder(node.right);
+            cnt += 2;
+        }
+    } // 유사 중위 순회
+
+    static int count (Node node, int cnt_node){
+        while (node.right != null) {
+            cnt_node--;
+            node = node.right;
+        }
+        return cnt_node;
+    } // root 기준 맨 오른쪽에 있는 자식노드의 갯수만큼 cnt 감소
+
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int root = Integer.parseInt(st.nextToken());
+            int left = Integer.parseInt(st.nextToken());
+            int right = Integer.parseInt(st.nextToken());
+            tree.putIfAbsent(root, new Node(root));
+            if (left != -1) {
+                tree.putIfAbsent(left, new Node(left));
+                tree.get(root).left = tree.get(left);
+            }
+            if (right != -1) {
+                tree.putIfAbsent(right, new Node(right));
+                tree.get(root).right = tree.get(right);
+            }
+        }
+
+        Node node = tree.get(1);
+        likeInorder(node);
+//        count(node, cnt);
+        System.out.println(count(node, cnt));
+    } // main
+}

--- a/algorithms/implementation/GainLee/Boj_2615.java
+++ b/algorithms/implementation/GainLee/Boj_2615.java
@@ -1,0 +1,66 @@
+package implementation.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_2615 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int[][] map = new int[20][20];
+    static int[] dx = {-1, 1, 0, 1};
+    static int[] dy = {1, 1, 1, 0};
+
+    static Boolean checkWin (int x, int y, int dx, int dy, int color) {
+        int cnt = 0;
+        int nx = x;
+        int ny = y;
+
+        while (nx >= 1 && ny >= 1 && nx <= 19 && ny <= 19 && map[nx][ny] == color) {
+            nx += dx;
+            ny += dy;
+            cnt++;
+        }
+
+        if (cnt != 5) return false;
+
+        int pre_x = x - dx;
+        int pre_y = y - dy;
+
+        if (pre_x >= 1 && pre_y >= 1 && pre_x <= 19 && pre_y <= 19 && map[pre_x][pre_y] == color) {
+            return false;
+        }
+
+        return true;
+    } // checkWin
+
+    public static void main(String[] args) throws IOException {
+        boolean found = false;
+        for (int i = 1; i < 20; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j < 20; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        } // for
+
+        for (int i = 1; i < 20; i++) {
+            for (int j = 1; j < 20; j++) {
+                if (map[i][j] == 0) continue;
+
+                int color = map[i][j];
+                for (int k = 0; k < 4; k++) {
+                    if (checkWin(i, j, dx[k], dy[k], color)) {
+                        found = true;
+                        System.out.println(color);
+                        System.out.println(i + " " + j);
+                        return;
+                    }
+                }
+
+            }
+        } // for
+
+        if(!found) System.out.println(0);
+
+
+    } // main
+}


### PR DESCRIPTION
### ✅  **17276  | [배열돌리기](https://www.acmicpc.net/problem/17276) |   난이도  Silver V | 유형 구현**

### 📝 문제 설명
> 배열의 크기와 회전각도를 입력받은 뒤, 입력받은 배열을 회전시키는 문제입니다.

### 💡 풀이 설명
- 대각선, 행과 열에 따라서 조건문을 나누어 회전시키면 되는 문제입니다.
- 반복문을 이용해 45도씩 회전하는 방식으로 풀이했습니다. 
- 입력으로 음수의 각도가 들어오기 때문에 양수로 만들어주기 위해 360을 더하고 360으로 나누는 방식을 사용했습니다.
---

### ✅ **2615 | [오목](https://www.acmicpc.net/problem/2615) | 난이도: Silver V | 유형: 구현**

### 📝 문제 설명
> 같은 색의 돌이 연속으로 5개 놓여진 경우를 찾아 승패유무를 출력하고, 승리한 곳의 가장 왼쪽의 좌표를 출력합니다.

### 💡 풀이 설명
- -, |, /, \ 이렇게 4개의 경우로 나눠 조건문을 작성했습니다.
- 6개가 연속할 경우는 승리한 것이 아님을 주의합니다. 
- 5개가 연속하더라도 이전 위치의 돌이 같은 색의 돌일경우 6개가 연속한 것임을 주의해야합니다.

---

### ✅ **14719 | [빗물](https://www.acmicpc.net/problem/14719) | 난이도: Gold V | 유형: 투포인터**

### 📝 문제 설명
>  블럭을 입력받고 담을 수 있는 최대 빗물의 양을 구하는 문제입니다.

### 💡 풀이 설명
- 투포인터를 이용해 문제를 해결했습니다.
- 0이 아닌 가장 왼쪽의 블록을 start, 0이 아닌 가장 오른쪽의 블록을 end로 둡니다.
- start, end를 비교하며, 작은 값을 이동시킵니다.
- 이때, 포인터를 이동하며 그 칸에 담을 수 있는 빗물의 양을 더합니다.

---

### ✅ **22856 | [트리 순회](https://www.acmicpc.net/problem/22856) | 난이도: Gold IV | 유형: 구현, 트리**

### 📝 문제 설명
> 유사 중위 순회를 하며 이동하는 횟수를 구하는 문제입니다.

### 💡 풀이 설명
- 자식 노드가 있다면 순회를 하고, 횟수는 2회씩 더합니다.
- 이때, 가장 오른쪽에 있는 자식노드들은 1회씩만 순회하므로, 가장 오른쪽의 자식노드의 갯수를 뺍니다.
