### PR TITLE
[ADD] k0000k 9주차

### DIFF
--- a/algorithms/graph_traversal/k0000k/Bj13549.java
+++ b/algorithms/graph_traversal/k0000k/Bj13549.java
@@ -1,0 +1,65 @@
+package graph_traversal.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    int time;
+    int location;
+
+    public Node(int time, int location) {
+        this.time = time;
+        this.location = location;
+    }
+}
+
+public class Bj13549 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static ArrayDeque<Node> queue = new ArrayDeque<>();
+    public static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        if (end < start) { // 도착점이 시작점보다 작은 숫자면 바로 종료
+            System.out.println(start - end);
+            return;
+        }
+
+        visited = new boolean[100001];
+        queue.addLast(new Node(0, start));
+        while (!queue.isEmpty()) {
+            Node node = queue.pollFirst();
+            int time = node.time;
+            int location = node.location;
+            if (location == end) { // 종료조건
+                System.out.println(time);
+                return;
+            }
+
+            // x에서 x + 1로 1칸 커지는 것 보다, 그보다 더 작은 값에서 2 곱해지는 것이 우선순위가 높다.
+            // 따라서, -1이 1보다 먼저 큐에 들어가야 한다.
+            int[] locations = new int[] {2 * location, location - 1, location + 1};
+            int[] times = new int[] {time, time + 1, time + 1};
+            for (int i = 0; i < locations.length; i++) {
+                if (isRange(locations[i]) && !visited[locations[i]]) {
+                    // 0-1 BFS 수행
+                    if (i == 0) { // 간선의 가중치가 0일때는 Queue 앞에 넣기
+                        queue.addFirst(new Node(times[i], locations[i]));
+                    }
+                    else { // 간선의 가중치가 1일때는 Queue 뒤에 넣기
+                        queue.addLast(new Node(times[i], locations[i]));
+                    }
+                    visited[locations[i]] = true; // 방문처리
+                }
+            }
+        }
+    }
+
+    private static boolean isRange(int idx) {
+        return (idx >= 0) && (idx < visited.length);
+    }
+}

--- a/algorithms/graph_traversal/k0000k/Bj16234.java
+++ b/algorithms/graph_traversal/k0000k/Bj16234.java
@@ -1,0 +1,108 @@
+package graph_traversal.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj16234 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[][] peoples;
+    public static int l;
+    public static int r;
+    public static int[][] directions = new int[][] {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        l = Integer.parseInt(st.nextToken());
+        r = Integer.parseInt(st.nextToken());
+
+        peoples = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                peoples[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        int answer = 0;
+        while (true) {
+            boolean flag = false;
+            boolean[][] visited = new boolean[n][n];
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (!visited[i][j] && isOpen(i, j)) { // 오늘 미방문 && 인접 국가와 차이 l 이상 r 이하
+                        flag = true;
+                        bfs(i, j, visited);
+                    }
+                    else {
+                        visited[i][j] = true;
+                    }
+                }
+            }
+            if (!flag) { // 오늘 어떤 노드에서도 변화가 없었다면 종료
+                break;
+            }
+            answer++;
+        }
+        System.out.println(answer);
+    }
+
+    // 인접 노드와의 차이가 l 이상 r 이하인 것이 1개라도 있으면 true 리턴
+    private static boolean isOpen(int i, int j) {
+        for (int[] dir : directions) {
+            int x = i + dir[0];
+            int y = j + dir[1];
+            if (isRange(x, y)) {
+                int diff = Math.abs(peoples[i][j] - peoples[x][y]);
+                if (diff >= l && diff <= r) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRange(int x, int y) {
+        return (x >= 0) && (x < peoples.length) && (y >= 0) && (y < peoples[0].length);
+    }
+
+    private static void bfs(int i, int j, boolean[][] visited) {
+        ArrayList<int[]> update = new ArrayList<>(); // 대상 노드를 저장하기 위한 List
+        ArrayDeque<int[]> queue = new ArrayDeque<>(); // BFS 탐색을 위한 Queue
+        queue.addLast(new int[] {i, j});
+        update.add(new int[] {i, j});
+        visited[i][j] = true;
+        while (!queue.isEmpty()) { // BFS 시작
+            int[] node = queue.pollFirst();
+            for (int[] dir : directions) {
+                int x = node[0] + dir[0];
+                int y = node[1] + dir[1];
+                if (isRange(x, y) && !visited[x][y]) {
+                    int diff = Math.abs(peoples[node[0]][node[1]] - peoples[x][y]);
+                    if (diff >= l && diff <= r) {
+                        update.add(new int[] {x, y});
+                        queue.addLast(new int[] {x, y});
+                        visited[x][y] = true;
+                    }
+                }
+            }
+        }
+
+        doUpdate(update);
+    }
+
+    // 국경이 열린 모든 국가 업데이트
+    private static void doUpdate(ArrayList<int[]> update) {
+        int sum = 0;
+        for (int[] node: update) {
+            sum += peoples[node[0]][node[1]];
+        }
+
+        int result = sum / update.size();
+        for (int[] node: update) {
+            peoples[node[0]][node[1]] = result;
+        }
+    }
+}

--- a/algorithms/graph_traversal/k0000k/Bj2206.java
+++ b/algorithms/graph_traversal/k0000k/Bj2206.java
@@ -1,0 +1,94 @@
+package graph_traversal.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Path {
+    int val;
+    int wall;
+    int x;
+    int y;
+
+    public Path(int val, int wall, int x, int y) {
+        this.val = val;
+        this.wall = wall;
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class Bj2206 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static String[][] board;
+    public static Path[][][] visited;
+    public static int[][] directions = new int[][] {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        board = new String[n][m];
+        for (int i = 0; i < n; i++) {
+            String[] input = br.readLine().split("");
+            board[i] = input;
+        }
+
+        visited = new Path[n][m][2];
+        for (int i = 0; i < visited.length; i++) {
+            for (int j = 0; j < visited[0].length; j++) {
+                for (int k = 0; k < 2; k++) {
+                    visited[i][j][k] = new Path(Integer.MAX_VALUE, k, i, j);
+                }
+            }
+        }
+
+        ArrayDeque<Path> queue = new ArrayDeque<>();
+        int val = Integer.parseInt(board[0][0]);
+        Path start = new Path(1, val, 0, 0);
+        queue.addLast(start);
+        visited[0][0][val] = start;
+
+        while (!queue.isEmpty()) {
+            Path pastPath = queue.pollFirst();
+            if (pastPath.x == n - 1 && pastPath.y == m - 1) {
+                System.out.println(pastPath.val);
+                return;
+            }
+
+            for (int[] dir : directions) {
+                int x = pastPath.x + dir[0];
+                int y = pastPath.y + dir[1];
+                if (isRange(x, y) && isUpdate(x, y, pastPath)) {
+                    if (board[x][y].equals("0")) { // 이동 하려는 칸이 0
+                        Path newPath = new Path(pastPath.val + 1, pastPath.wall, x, y);
+                        visited[x][y][pastPath.wall] = newPath;
+                        queue.addLast(newPath);
+                    }
+                    else if (pastPath.wall == 0) { // 이동 하려는 칸이 1이면서, 지금까지 부순 벽이 없음
+                        Path newPath = new Path(pastPath.val + 1, pastPath.wall + 1, x, y);
+                        visited[x][y][1] = newPath;
+                        queue.addLast(newPath);
+                    }
+                }
+            }
+        }
+        System.out.println(-1);
+    }
+
+    // 기존보다 유리한 경로일때만 갱신 -> 갱신이 이루어지는지 확인
+    private static boolean isUpdate(int x, int y, Path oldPath) {
+        int isWall = Integer.parseInt(board[x][y]);
+        if (isWall + oldPath.wall < 2) { // 벽을 두번 부술수는 없음
+            Path destPath = visited[x][y][isWall + oldPath.wall];
+            return oldPath.val + 1 < destPath.val; // 새로운 경로가 더 짧다면 true
+        }
+        return false;
+    }
+
+    // (x, y)가 범위 내부인지 확인
+    private static boolean isRange(int x, int y) {
+        return (x >= 0) && (x < board.length) && (y >= 0) && (y < board[0].length);
+    }
+}

--- a/algorithms/graph_traversal/k0000k/Bj2573.java
+++ b/algorithms/graph_traversal/k0000k/Bj2573.java
@@ -1,0 +1,105 @@
+package graph_traversal.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj2573 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[][] ice;
+    public static int[][] directions = new int[][] {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        ice = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                ice[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int answer = 0;
+        while (isOne()) { // 한 덩어리가 아닐 때까지 반복
+            answer++;
+            int[][] diff = new int[n][m]; // 인접한 0의 갯수를 저장하는 배열
+            for (int i = 0; i < ice.length; i++) {
+                for (int j = 0; j < ice[0].length; j++) {
+                    if (ice[i][j] > 0) {
+                        int cnt = 0;
+                        for (int[] dir : directions) {
+                            int x = i + dir[0];
+                            int y = j + dir[1];
+                            if (isRange(x, y) && ice[x][y] == 0) {
+                                cnt++;
+                            }
+                        }
+                        diff[i][j] = Math.min(cnt, ice[i][j]); // 얼음의 크기보다 인접한 0의 갯수가 많을 수 있음
+                    }
+                }
+            }
+            applyDiff(diff); // 얼음 크기 줄이기
+        }
+
+        // 반복을 빠져 나왔을 때 얼음이 남아있다면 두 덩이 이상으로 나누어진 경우
+        for (int i = 0; i < ice.length; i++) {
+            for (int j = 0; j < ice[0].length; j++) {
+                if (ice[i][j] > 0) {
+                    System.out.println(answer);
+                    return;
+                }
+            }
+        }
+
+        System.out.println(0);
+    }
+
+    // 남아있는 얼음이 한 덩어리라면 true 리턴
+    private static boolean isOne() {
+        boolean[][] visited = new boolean[ice.length][ice[0].length];
+        int result = 0;
+        ArrayDeque<int[]> queue = new ArrayDeque<>();
+        for (int i = 0; i < visited.length; i++) {
+            for (int j = 0; j < visited[0].length; j++) {
+                if (ice[i][j] > 0 && !visited[i][j]) { // 미방문한 얼음 발견하면 BFS 시작
+                    result += 1;
+                    queue.addLast(new int[]{i, j});
+                    visited[i][j] = true;
+                    while (!queue.isEmpty()) {
+                        int[] node = queue.pollFirst();
+                        for (int[] dir : directions) {
+                            int x = node[0] + dir[0];
+                            int y = node[1] + dir[1];
+                            if (isRange(x, y) && ice[x][y] > 0 && !visited[x][y]) {
+                                queue.addLast(new int[]{x, y});
+                                visited[x][y] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (result == 1) {
+            return true;
+        }
+        return false;
+    }
+
+    // 인덱스가 범위 내에 있으면 true 리턴
+    private static boolean isRange(int x, int y) {
+        return (x >= 0) && (x < ice.length) && (y >= 0) && (y < ice[0].length);
+    }
+
+    // 얼음 크기 줄이기 일괄 적용
+    private static void applyDiff(int[][] diff) {
+        for (int i = 0; i < diff.length; i++) {
+            for (int j = 0; j < diff[0].length; j++) {
+                if (ice[i][j] > 0) {
+                    ice[i][j] -= diff[i][j];
+                }
+            }
+        }
+    }
+}

--- a/algorithms/graph_traversal/k0000k/Bj2668.java
+++ b/algorithms/graph_traversal/k0000k/Bj2668.java
@@ -1,0 +1,58 @@
+package graph_traversal.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj2668 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[] nums;
+    public static boolean[] visited;
+    public static ArrayList<Integer> answer = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        nums = new int[n + 1];
+        for (int i = 1; i < n + 1; i++) {
+            nums[i] = Integer.parseInt(br.readLine());
+            if (i == nums[i]) { // 미리 answer에 담아놓기
+                answer.add(i);
+            }
+        }
+
+        visited = new boolean[n + 1];
+        for (int i = 1; i < n + 1; i++) {
+            if (!visited[i]) {
+                ArrayList<Integer> result = dfs(i, new ArrayList<>(), new boolean[n + 1]);
+                if (!result.isEmpty()) { // 유효한 사이클이 있다면
+                    for (Integer num : result) { // answer과 visited에 반영
+                        visited[num] = true;
+                        answer.add(num);
+                    }
+                }
+            }
+        }
+
+        Collections.sort(answer);
+        System.out.println(answer.size());
+        for (Integer num : answer) {
+            System.out.println(num);
+        }
+    }
+
+    private static ArrayList<Integer> dfs(int i, ArrayList<Integer> result, boolean[] currentVisited) {
+        if (i == nums[i]) { // 탐색 도중 이 경우가 발생하면 절대 정답에 포함 될 수 없음.
+            return new ArrayList<>();
+        }
+        if (!currentVisited[i] && result.contains(nums[i])) { // 현재 노드에 처음 방문하지만 이미 result에 숫자가 있는경우
+            return new ArrayList<>();
+        }
+        if (currentVisited[i]) { // 사이클 완성
+            return result;
+        }
+        currentVisited[i] = true;
+        result.add(nums[i]);
+        return dfs(nums[i], result, currentVisited);
+    }
+
+}


### PR DESCRIPTION
### ✅ 13549 | [숨바꼭질3](https://www.acmicpc.net/problem/13549) | 난이도: 골드5 | 유형: 0-1 BFS

### 📝 문제 설명
> 0-1 BFS로 이동 동작 간의 우선순위를 잘 파악하여 목적지까지의 최단 거리를 구하는 문제입니다.
### 💡 풀이 설명
정말 많은 고난이 있었습니다... **결론은 0-1 BFS를 사용할 땐 우선순위를 꼼꼼히 따지자.**
- BFS는 모든 간선의 가중치가 같아야만 최단거리를 구할수 있다는 것을 놓쳤습니다. 이 문제와 같은 상황에서는 0-1 BFS를 사용해야 하는데, 가장 비용이 적게 드는 선택지인 *2를 큐의 앞 부분에 넣는 방법입니다.
- -1이 +1보다 우선순위가 높다는걸 이해하는데 오래 걸렸습니다... x에서 x+1로 한 칸 올라가는 것 보다는, 그보다 더 작은 수에서 *2해서 오는 더 우선순위가 높으므로 -1이 더 먼저 큐에 들어가야만 합니다.
---

### ✅ 2668 | [숫자고르기](https://www.acmicpc.net/problem/2668) | 난이도: 골드5 | 유형: DFS

### 📝 문제 설명
> DFS로 탐색하며 문제에서 제시하는 올바른 사이클을 모두 찾는 문제입니다.
### 💡 풀이 설명
- 반례를 미리 잘 생각해두는게 중요한 문제인것 같습니다. 현재 노드에 처음 방문하지만 이미 같은 숫자를 만난적 있는 경우, 정답이 여러개의 사이클로 이루어질수 있다는 점을 놓쳐서 틀렸었네요...
---

### ✅ 16234 | [인구이동](https://www.acmicpc.net/problem/16234) | 난이도: 골드4 | 유형: BFS

### 📝 문제 설명
> 인구수가 인접 노드와 l 이상 r 이하의 차이인 경우가 하나라도 있으면 전체를 BFS로 순회하면 열린 국경을 찾고, 인구 수를 업데이트합니다.
### 💡 풀이 설명
- 크게 어려움은 없었지만, 메소드 분리에 신경쓰지 않으면 복잡도가 기하급수적으로 상승할만한 문제입니다.
---

### ✅ 2573 | [빙산](https://www.acmicpc.net/problem/2573) | 난이도: 골드4 | 유형: BFS

### 📝 문제 설명
> BFS를 사용해서 빙하 덩어리를 체크하고, 인접한 0의 갯수만큼 크기를 줄여갑니다.
### 💡 풀이 설명
- BFS라고 티가 팍팍나는.. 문제입니다.
- 빙하 덩어리 갯수 확인과 크기 줄이기는 분리해서 생각해야 합니다. 바로 바꿔버리면 앞에서 바뀐 값에 뒷 값이 영향을 받습니다.
---

### ✅ 2206 | [벽 부수고 이동하기](https://www.acmicpc.net/problem/2206) | 난이도: 골드3 | 유형: BFS

### 📝 문제 설명
> BFS를 기반으로 최단 거리를 탐색해야 합니다.
### 💡 풀이 설명
어려웠습니다...
- 처음에는 그냥 BFS로 풀 수 있을거라고 생각했습니다. 근데 그러면 골3이 아니겠죠..
- 어떤 노드 (x, y)에 대해 (x, y)까지 올 수 있는 모든 경로 중 길이가 짧고, 길이가 같다면 부순 벽이 없는 경로가 우선순위가 높다고 생각했습니다. 하지만 예외가 있다는 걸 알게 되었습니다.
- (x, y)까지 오는 경로 중 벽을 부순 경로와 부수지 않은 경로 중에 어떤 경로가 최적인지 알 수 없습니다. 따라서, 두 가지 케이스 모두 최적 경로를 저장해 나가야 합니다.
---