### PR TITLE
[ADD] GainLee 9주차

### DIFF
--- a/algorithms/brute_force/GainLee/Boj_21315.java
+++ b/algorithms/brute_force/GainLee/Boj_21315.java
@@ -1,0 +1,4 @@
+package brute_force.GainLee;
+
+public class Boj_21315 {
+}

--- a/algorithms/graph_traversal/GainLee/Boj_13549.java
+++ b/algorithms/graph_traversal/GainLee/Boj_13549.java
@@ -1,0 +1,75 @@
+package graph_traversal.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+class State {
+    public int position;
+    public int time;
+
+    public State (int position, int time) {
+        this.position = position;
+        this.time = time;
+    }
+}
+
+public class Boj_13549 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static final int MAX_POSITION = 100_000;
+    static final int INF = 100_000;
+    static int n; static int k; static int sec = 0;
+    static int[] visited = new int[MAX_POSITION+1];
+    static Queue<State> queue = new LinkedList<>();
+
+    static void bfs(){
+        Arrays.fill(visited, INF);
+        visited[n] = 0;
+        queue.add(new State(n, 0));
+
+        while (!queue.isEmpty()) {
+            State current = queue.remove();
+
+            // np 는 new_positon의 약자
+            // np1 : n-1
+            // np2 : n+1
+            // np3 : n*2
+            int np1 = current.position - 1;
+            if (isValid(np1) && visited[np1] > current.time + 1) {
+                visited[np1] = current.time+1;
+                queue.add(new State(np1, visited[np1]));
+            }
+
+            int np2 = current.position + 1;
+            if (isValid(np2) && visited[np2] > current.time + 1) {
+                visited[np2] = current.time+1;
+                queue.add(new State(np2, visited[np2]));
+            }
+
+            int np3 = current.position * 2;
+            if (isValid(np3) && visited[np3] > current.time) {
+                visited[np3] = current.time;
+                queue.add(new State(np3, visited[np3]));
+            }
+        } // while
+        sec = visited[k];
+    } // bfs
+
+    static boolean isValid (int position) {
+        return 0 < position && position <= MAX_POSITION;
+    }
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        if (n >= k) {
+            sec = n - k;
+        } else {
+            bfs();
+        }
+
+        System.out.println(sec);
+    } // main
+}

--- a/algorithms/graph_traversal/GainLee/Boj_16234.java
+++ b/algorithms/graph_traversal/GainLee/Boj_16234.java
@@ -1,0 +1,98 @@
+package graph_traversal.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_16234 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int[][] map;
+    static boolean[][] visit;
+    static int[] di = {-1, 1, 0, 0};
+    static int[] dj = {0, 0, -1, 1};
+    static Queue<int[]> queue = new LinkedList<>();
+    static int l; static int r;
+    static int n;
+
+    public static boolean bfs(int i, int j) {
+        visit[i][j] = true;
+        queue.add(new int[] {i, j});
+        List<int[]> union = new ArrayList<>();
+        int sum = map[i][j];
+        union.add(new int[] {i, j});
+
+//        System.out.println(i + " " + j + "탐색 중");
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int ci = cur[0];
+            int cj = cur[1];
+
+            for (int d = 0; d < 4; d++) {
+                int ni = ci + di[d];
+                int nj = cj + dj[d];
+                if (isValid(ni, nj) && !visit[ni][nj]) {
+                    int diff = Math.abs(map[ci][cj] - map[ni][nj]);
+//                    System.out.println(i + ", " + j + "와 " + ni + ", " + nj + "의 diff = " + diff);
+                    if (diff >= l && diff <= r) {
+                        queue.offer(new int[] {ni, nj});
+                        union.add(new int[] {ni, nj});
+                        visit[ni][nj] = true;
+                        sum += map[ni][nj];
+                    }
+                }
+            } // 상하좌우 국가 탐색
+        } // while
+
+        // 인구 분배
+        int avg = sum / union.size();
+        for (int[] u : union) {
+            map[u[0]][u[1]] = avg;
+        }
+
+        if (union.size() >= 2) return true;
+        return false;
+    } // bfs
+
+    public static boolean isValid(int i, int j) {
+        if (i >= 0 && j >= 0 && i < n && j < n) return true;
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        l = Integer.parseInt(st.nextToken());
+        r = Integer.parseInt(st.nextToken());
+
+        map = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int count = 0;
+
+        while (true) {
+            visit = new boolean[n][n];
+            boolean moved = false;
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (!visit[i][j]) {
+                        if (bfs(i, j)) {
+                            moved = true;
+                        }
+                    }
+                }
+            }
+            if (!moved) break;
+            count++;
+        }
+
+        System.out.println(count);
+
+    } // main
+}

--- a/algorithms/graph_traversal/GainLee/Boj_2206.java
+++ b/algorithms/graph_traversal/GainLee/Boj_2206.java
@@ -1,0 +1,69 @@
+package graph_traversal.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+// Boj_2206 벽 부수고 이동하기
+public class Boj_2206 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int[][] map;
+    static boolean[][] visit;
+    static int n; static int m;
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int[][] new_map; // 거리 저장용 map
+    static Queue<int[]> queue = new LinkedList<>();
+
+    public static void bfs (int x, int y) {
+        visit[x][y] = true;
+        queue.offer(new int[] {x, y});
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int cx = cur[0];
+            int cy = cur[1];
+            for (int d = 0; d < 4; d++) {;
+                int nx = cx + dx[d];
+                int ny = cy + dy[d];
+                if (isValid(nx, ny) && !visit[nx][ny] && map[nx][ny] == 0) {
+                    visit[nx][ny] = true;
+                    new_map[nx][ny] += 1;
+                    queue.offer(new int[] {nx, ny});
+                }
+            }
+        } // while
+
+
+    } // bfs
+
+    public static boolean isValid (int x, int y) {
+        if (x >= 0 && y >= 0 && x < n && y < m) return true;
+        return false;
+    } // isValid
+
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new int[n][m];
+        new_map = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < m; j++) {
+                map[i][j] = line.charAt(j) - '0';
+            }
+        } // map 입력
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (!visit[i][j]) {
+                    bfs(i, j);
+                }
+            }
+        }
+
+    } // main
+}

--- a/algorithms/graph_traversal/GainLee/Boj_2206.java
+++ b/algorithms/graph_traversal/GainLee/Boj_2206.java
@@ -8,31 +8,56 @@ public class Boj_2206 {
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static StringTokenizer st;
     static int[][] map;
-    static boolean[][] visit;
+    static boolean[][][] visit;
     static int n; static int m;
     static int[] dx = {-1, 1, 0, 0};
     static int[] dy = {0, 0, -1, 1};
-    static int[][] new_map; // 거리 저장용 map
-    static Queue<int[]> queue = new LinkedList<>();
+    static Queue<Node> queue = new LinkedList<>();
 
-    public static void bfs (int x, int y) {
-        visit[x][y] = true;
-        queue.offer(new int[] {x, y});
+    public static class Node {
+        int x;
+        int y;
+        int count;
+        int wall;
+
+        public Node (int x, int y, int count, int wall) {
+            this.x = x;
+            this.y = y;
+            this.count = count;
+            this.wall = wall;
+        }
+    }
+
+    public static int bfs (int x, int y) {
+        visit[x][y][0] = true;
+        visit[x][y][1] = true;
+        queue.add(new Node(x, y, 1, 0));
 
         while (!queue.isEmpty()) {
-            int[] cur = queue.poll();
-            int cx = cur[0];
-            int cy = cur[1];
+            Node cur = queue.poll();
+
+            if (cur.x == n-1 && cur.y == m-1) return cur.count;
+            int cx = cur.x ;
+            int cy = cur.y;
             for (int d = 0; d < 4; d++) {;
                 int nx = cx + dx[d];
                 int ny = cy + dy[d];
-                if (isValid(nx, ny) && !visit[nx][ny] && map[nx][ny] == 0) {
-                    visit[nx][ny] = true;
-                    new_map[nx][ny] += 1;
-                    queue.offer(new int[] {nx, ny});
+                if (isValid(nx, ny)){
+                    if (map[nx][ny] == 0) {
+                        if (visit[nx][ny][cur.wall] == false) {
+                            queue.add(new Node (nx, ny, cur.count + 1, cur.wall));
+                            visit[nx][ny][cur.wall] = true;
+                        }
+                    } else if (map[nx][ny] == 1) {
+                        if (cur.wall == 0 && visit[nx][ny][1] == false) {
+                            queue.add(new Node(nx, ny, cur.count + 1, 1));
+                            visit[nx][ny][1] = true;
+                        }
+                    }
                 }
             }
         } // while
+        return -1;
 
 
     } // bfs
@@ -49,7 +74,6 @@ public class Boj_2206 {
         m = Integer.parseInt(st.nextToken());
 
         map = new int[n][m];
-        new_map = new int[n][m];
         for (int i = 0; i < n; i++) {
             String line = br.readLine();
             for (int j = 0; j < m; j++) {
@@ -57,13 +81,7 @@ public class Boj_2206 {
             }
         } // map 입력
 
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < m; j++) {
-                if (!visit[i][j]) {
-                    bfs(i, j);
-                }
-            }
-        }
-
+        visit = new boolean[n][m][2];
+        System.out.println(bfs(0, 0));
     } // main
 }

--- a/algorithms/graph_traversal/GainLee/Boj_2573.java
+++ b/algorithms/graph_traversal/GainLee/Boj_2573.java
@@ -1,0 +1,93 @@
+package graph_traversal.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_2573 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n; static int m;
+    static int[][] map;
+    static int[][] new_map;
+    static boolean[][] visited;
+    static Queue<int[]> queue = new LinkedList<>();
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int years = 0;
+
+    static void bfs (int x, int y) {
+        visited[x][y] = true;
+        queue.offer(new int[] {x, y});
+        new_map = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                new_map[i][j] = map[i][j];
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int cx = cur[0];
+            int cy = cur[1];
+            visited[cx][cy] = true;
+
+            for (int d = 0; d < 4; d++) {
+                int nx = cx + dx[d];
+                int ny = cy + dy[d];
+                if(!visited[nx][ny] && isValid(nx, ny) && map[nx][ny] != 0) {
+                    visited[nx][ny] = true;
+                    queue.offer(new int[] {nx, ny});
+                }
+                if (isValid(nx, ny) && map[nx][ny] == 0) {
+                    new_map[cx][cy]--;
+                    if (new_map[cx][cy] < 0) new_map[cx][cy] = 0;
+                }
+            }
+        }
+
+        map = new_map;
+
+    }
+
+    static boolean isValid (int x, int y) {
+        if (x >= 0 && y >= 0 && x < n && y < m) return true;
+        return false;
+    } // isValid
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+         map = new int[n][m];
+        new_map = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        while (true) {
+            int cnt = 0;
+            visited = new boolean[n][m];
+            for (int i = 1; i < n-1; i++) {
+                for (int j = 1; j < m-1; j++) {
+                    if (!visited[i][j] && map[i][j] != 0){
+                        bfs(i, j);
+                        cnt++;
+                    }
+                }
+            }
+            if (cnt == 0) {
+                System.out.println(0);
+                break;
+            }
+            if (cnt > 1) {
+                System.out.println(years);
+                break;
+            }
+            years++;
+
+        }
+    } // main
+}

--- a/algorithms/graph_traversal/GainLee/Boj_2668.java
+++ b/algorithms/graph_traversal/GainLee/Boj_2668.java
@@ -1,0 +1,4 @@
+package graph_traversal.GainLee;
+
+public class Boj_2668 {
+}

--- a/algorithms/graph_traversal/GainLee/Boj_2668.java
+++ b/algorithms/graph_traversal/GainLee/Boj_2668.java
@@ -1,4 +1,46 @@
 package graph_traversal.GainLee;
 
+import java.io.*;
+import java.util.*;
+
 public class Boj_2668 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n; static int cnt = 0;
+    static int[] map;
+    static boolean[] visited ;
+    static ArrayList<Integer> res_arr = new ArrayList<>();
+
+    static void dfs(int start, int target) {
+        if (!visited[map[start]]) {
+            visited[map[start]] = true;
+            dfs(map[start], target);
+            visited[map[start]] = false;
+        }
+        if (map[start] == target) res_arr.add(target);
+
+    } // dfs
+
+    public static void main(String[] args) throws IOException {
+        // 입력
+        n = Integer.parseInt(br.readLine());
+        map = new int[n+1];
+        for (int i = 1; i <= n; i++) {
+            map[i] = Integer.parseInt(br.readLine());
+        } // for
+
+        visited = new boolean[n+1];
+
+        // dfs 로 사이클 검사
+        for (int i = 1; i <= n; i++) {
+            visited[i] = true;
+            dfs(i, i);
+            visited[i] = false;
+        }
+
+        Collections.sort(res_arr);
+        System.out.println(res_arr.size());
+        for (int i = 0; i < res_arr.size(); i++) {
+            System.out.println(res_arr.get(i));
+        }
+    } //main
 }


### PR DESCRIPTION
### ✅ 13549 | [숨바꼭질3](https://www.acmicpc.net/problem/13549) | 난이도: Gold V | 유형: BFS

### 📝 문제 설명
> 현재 위치에서 동생이 있는 곳까지 이동할 때 소요되는 시간의 최솟값을 구하는 문제입니다. 
> 현재 위치 x 에서 x-1, x+1, 2*x로 이동할 수 있으며, 2*x는 0초, +-1 은 1초가 걸립니다.

### 💡 풀이 설명
- 문제 풀이 방향에 대한 감을 전혀 잡지 못해 다른 사람의 풀이를 참고하였습니다.
- bfs 를 이용했습니다. 현재 위치에서 -1, +1 , *2 이동했을 때의 위치에 소요된 시간을 갱신시킨 뒤 queue에 넣습니다. 

---
### ✅ 16234 | [인구이동](https://www.acmicpc.net/problem/16234) | 난이도: Gold IV | 유형: BFS

### 📝 문제 설명
> 인접한 국가들의 인구수의 차가 주어진 수 (l, r) 사이에 있다면, 하루동안 연합을 맺습니다.
> 연합국가끼리는 인구가 이동하는데, 인구 이동의 결과는 연합국가 인구수의 평균값입니다.

### 💡 풀이 설명
- bfs 를 이용했습니다.
- bfs() 함수 속의 인덱스 실수로 오류를 잡느라 고생했습니다 ㅎㅎ

---
### ✅ 2668 | [숫자 고르기](https://www.acmicpc.net/problem/2668) | 난이도: Gold IV | 유형: DFS

### 📝 문제 설명
> 첫째 줄에서 숫자를 적절히 뽑으면, 그 뽑힌 정수들이 이루는 집합과, 뽑힌 정수들의 바로 밑의 둘째 줄에 들어있는 정수들이 이루는 집합이 같아지는 수들을 구하는 문제입니다.

### 💡 풀이 설명
- 이 문제는 사이클을 찾아야하는 문제입니다. 그런데 사이클을 찾는 방법을 구현하지 못해 다른 사람의 풀이를 참고하였습니다.
- dfs 를 이용했습니다.
- 사이클을 찾기 위해 여러 변수들을 사용했었는데, tartget 이라는 매개변수의 사용과 dfs() 호출 이후 visited를 false로 바꿔주면 되는 거였네요~

---
### ✅ 2573 | [빙산](https://www.acmicpc.net/problem/2573) | 난이도: Gold IV | 유형: BFS

### 📝 문제 설명
> BFS를 이용해 0과 인접한 곳의 숫자를 인접한 0의 개수만큼 감소시켜야하는 문제입니다.

### 💡 풀이 설명
- 이 문제는 두개의 map을 이용해야합니다! 기존의 map에 갱신시킨다면, 갱신된 값들도 다른 값들이 영향을 받습니다.

---
### ✅ 2206 | [벽 부수고 이동하기](https://www.acmicpc.net/problem/2206) | 난이도: Gold III | 유형: BFS

### 📝 문제 설명
> 최단거리를 찾는 문제입니다. 이동중 단 한 번 벽을 부술 수 있습니다.

### 💡 풀이 설명
- 이 문제는 3차원 visited 를 이용해 벽을 부수는 경우를 고려해야 하는 문제입니다.
- 해당 위치까지 도달 할때 벽을 부순 경우와 부수지 않은 경우 중 어떤 것이 더 최적인지 알 수 없기 때문입니다!.
- dp 문제 중 징검다리 건너기 라는 문제와 비슷합니다. (이동 중 매우 큰 점프는 단 한번만 할 수 있음)

