### PR TITLE
[ADD] GainLee 10주차

### DIFF
--- a/algorithms/brute_force/GainLee/Boj_15661.java
+++ b/algorithms/brute_force/GainLee/Boj_15661.java
@@ -1,0 +1,66 @@
+package brute_force.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_15661 {
+    static int[][] arr;
+    static boolean[] visited;
+    static int n;
+    static int min = 100_0000;
+
+    static void dfs(int index) {
+        if (index == n) {
+            List<Integer> team_a = new ArrayList<>();
+            List<Integer> team_b = new ArrayList<>();
+
+            for (int i = 0; i < n; i++) {
+                if (visited[i]) team_a.add(i);
+                else team_b.add(i);
+            }
+
+            if (team_a.isEmpty() || team_b.isEmpty()) return;
+
+            int score_a = calc(team_a);
+            int score_b = calc(team_b);
+            min = Math.min(min, Math.abs(score_a - score_b));
+            return;
+        }
+
+        visited[index] = true;
+        dfs(index + 1);
+        visited[index] = false;
+        dfs(index + 1);
+    }
+
+    static int calc (List<Integer> team) {
+        int sum = 0;
+        for (int i = 0; i < team.size(); i++) {
+            for (int j = i+1; j < team.size(); j++) {
+                int a = team.get(i);
+                int b = team.get(j);
+                sum += arr[a][b] + arr[b][a];
+            }
+        }
+        return sum;
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        n = Integer.parseInt(br.readLine());
+        arr  = new int[n][n];
+        visited = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0);
+        System.out.println(min);
+
+    } // main
+}

--- a/algorithms/brute_force/GainLee/Boj_21315.java
+++ b/algorithms/brute_force/GainLee/Boj_21315.java
@@ -1,4 +1,36 @@
 package brute_force.GainLee;
 
+import java.io.*;
+import java.util.*;
+
 public class Boj_21315 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int[] card;
+    static int[] nums;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        card = new int[n];
+        nums = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            card[i] = Integer.parseInt(st.nextToken());
+            nums[i] = i+1;
+        } // card 초기화
+
+        int k;
+        int i = 0;
+        while (true) {
+            if (card[n-1] == 1 || card[n-2] == 1) {
+                break;
+            }
+            int[] new_card = new int[n];
+
+
+        } //
+
+
+        System.out.println();
+    } // main
 }


### PR DESCRIPTION
### ✅ 15661 | [링크와 스타트](https://www.acmicpc.net/problem/15661) | 난이도: Gold  | 유형: 완전 탐색

### 📝 문제 설명
> 능력치의 차가 최소가 되는 2개의 팀을 구성하는 문제입니다.

### 💡 풀이 설명
- 어려웠습니다... 일단 모든 선수에 대해 고려하기 위해 현재 index가 true 일때 다음 index의 dfs를 한번 호출하고, false일때의 다음 index의 dfs를 한번 호출합니다.
- (index == n)일때 모든 선수에 대해 방문처리(T or F) 가 끝났다면, visited를 이용해 팀 a, b로 나눕니다. 
- calc 메서드를 이용해 팀의 능력치를 구합니다.
- 차이의 최소값을 구하고 출력합니다.
