### PR TITLE
 [ADD] k0000k 10주차

### DIFF
--- a/algorithms/brute_force/k0000k/Bj14500.java
+++ b/algorithms/brute_force/k0000k/Bj14500.java
@@ -1,0 +1,70 @@
+package brute_force.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj14500 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[][] nums;
+    public static int answer = 0;
+    public static int[][] directions = new int[][] {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        nums = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                nums[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                ArrayList<int[]> selected = new ArrayList<>();
+                selected.add(new int[] {i, j});
+                findMax(selected, nums[i][j]);
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    public static void findMax(ArrayList<int[]> selected, int sum) {
+        if (selected.size() == 4) {
+            answer = Math.max(answer, sum);
+            return;
+        }
+
+        int length = selected.size();
+        for (int i = 0; i < length; i++) {
+            int[] node = selected.get(i);
+            for (int[] dir : directions) {
+                int x = node[0] + dir[0];
+                int y = node[1] + dir[1];
+                if (isRange(x, y) && isNotIn(selected, x, y)) {
+                    selected.add(new int[]{x, y});
+                    findMax(selected, sum + nums[x][y]);
+                    selected.remove(selected.size() - 1);
+                }
+            }
+        }
+    }
+
+    private static boolean isRange(int x, int y) {
+        return (x >= 0) && (x < nums.length) && (y >= 0) && (y < nums[0].length);
+    }
+
+    private static boolean isNotIn(ArrayList<int[]> selected, int x, int y) {
+        for (int[] node : selected) {
+            if (node[0] == x && node[1] == y) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/algorithms/brute_force/k0000k/Bj15661.java
+++ b/algorithms/brute_force/k0000k/Bj15661.java
@@ -1,0 +1,85 @@
+package brute_force.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj15661 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static StringTokenizer st;
+    public static int[][] table;
+    public static ArrayList<ArrayList<Integer>> combination = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        table = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                table[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        makeAllCombinations();
+
+        int answer = Integer.MAX_VALUE;
+        for (ArrayList<Integer> list : combination) {
+            ArrayList<Integer> anotherTeam = findAnotherTeam(list);
+            int power1 = calcPower(list);
+            int power2 = calcPower(anotherTeam);
+            int diff = Math.abs(power2 - power1);
+            answer = Math.min(answer, diff);
+        }
+
+        System.out.println(answer);
+    }
+
+    private static void makeAllCombinations() {
+        for (int i = 1; i <= table.length / 2; i++) {
+            // 0 ~ (n - 1)에서 i개 조합
+            makeCombination(i, 0, new ArrayList<>());
+        }
+    }
+
+    private static void makeCombination(int i, int cnt, ArrayList<Integer> list) {
+        if (cnt > table.length) {
+            return;
+        }
+        if (list.size() == i) {
+            combination.add(list);
+            return;
+        }
+        makeCombination(i, cnt + 1, new ArrayList<>(list));
+        list.add(cnt);
+        makeCombination(i, cnt + 1, new ArrayList<>(list));
+    }
+
+    private static ArrayList<Integer> findAnotherTeam(ArrayList<Integer> team) {
+        ArrayList<Integer> anotherTeam = new ArrayList<>();
+        int idx = 0;
+        int num = 0;
+        while (num < table.length) {
+            if (idx < team.size() && num == team.get(idx)) {
+                idx++;
+                num++;
+                continue;
+            }
+            anotherTeam.add(num);
+            num++;
+        }
+        return anotherTeam;
+    }
+
+    private static int calcPower(ArrayList<Integer> team) {
+        int result = 0;
+        for (int i = 0; i < team.size(); i++) {
+            int idxI = team.get(i);
+            for (int j = i + 1; j < team.size(); j++) {
+                int idxJ = team.get(j);
+                result += table[idxI][idxJ];
+                result += table[idxJ][idxI];
+            }
+        }
+        return result;
+    }
+}

--- a/algorithms/brute_force/k0000k/Bj21278.java
+++ b/algorithms/brute_force/k0000k/Bj21278.java
@@ -1,0 +1,76 @@
+package brute_force.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj21278 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[][] city;
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        city = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            Arrays.fill(city[i], 10000);
+            city[i][i] = 0;
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            city[a - 1][b - 1] = 1;
+            city[b - 1][a - 1] = 1;
+        }
+
+        for (int k = 0; k < n; k++) {
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    int current = city[i][j];
+                    int after = city[i][k] + city[k][j];
+                    if (current > after) {
+                        city[i][j] = after;
+                        city[j][i] = after;
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                boolean[] visited = new boolean[n];
+
+            }
+        }
+
+        int min = Integer.MAX_VALUE;
+        int[] chickens = new int[2];
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                int result = 0;
+                for (int k = 0; k < n; k++) {
+                    int shortest = Math.min(city[k][i], city[k][j]);
+                    result += (2 * shortest);
+                }
+                if (result < min) {
+                    min = result;
+                    chickens[0] = i;
+                    chickens[1] = j;
+                }
+            }
+        }
+
+        System.out.println((chickens[0] + 1) + " " + (chickens[1] + 1) + " " + min);
+
+//        for (int i = 0; i < n; i++) {
+//            for (int j = 0; j < n; j++) {
+//                System.out.print(city[i][j] + " ");
+//            }
+//            System.out.println();
+//        }
+    }
+}

--- a/algorithms/brute_force/k0000k/Bj21315.java
+++ b/algorithms/brute_force/k0000k/Bj21315.java
@@ -1,0 +1,93 @@
+package brute_force.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+
+public class Bj21315 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[] cards;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        cards = new int[n];
+        for (int i = 0; i < n; i++) {
+            cards[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int maxK = findMaxK(n); // 최대 k값 찾기
+        int[] init = makeInitArr(n); // 1, 2, 3, ... n 배열 생성
+        for (int i = 1; i <= maxK; i++) {
+            // 첫 번째 (2, i)-섞기
+            int[] arr = shuffleCards(init.clone(), i);
+            for (int j = 1; j <= maxK; j++) {
+                // 두 번째 (2, j)-섞기
+                int[] result = shuffleCards(arr.clone(), j);
+                if (isEqualCardSet(result)) {
+                    System.out.println(i + " " + j);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static int[] makeInitArr(int n) {
+        int[] arr = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = i + 1;
+        }
+        return arr;
+    }
+
+    private static int findMaxK(int n) {
+        int k = 1;
+        int multiple = 2;
+        while (multiple < n) {
+            multiple *= 2;
+            k += 1;
+        }
+        return k - 1;
+    }
+
+    private static int[] shuffleCards(int[] arr, int k) {
+        int[] newArr = new int[arr.length];
+        int powOf2 = (int) Math.pow(2, k);
+        // 1번째 단계
+        int startIdx = arr.length - powOf2;
+        int idx = 0;
+        for (int i = startIdx; i < arr.length; i++) {
+            newArr[idx++] = arr[i];
+        }
+
+        idx = 0;
+        for (int i = powOf2; i < arr.length; i++) {
+            newArr[i] = arr[idx++];
+        }
+
+        // 이후 단계
+        for (int i = 0; i < k; i++) {
+            int half = powOf2 / 2;
+            for (int j = 0; j < half; j++) {
+                // newArr[j]와 newArr[j + half]를 스왑
+                int temp = newArr[j];
+                newArr[j] = newArr[j + half];
+                newArr[j + half] = temp;
+            }
+            powOf2 /= 2;
+        }
+
+        return newArr;
+    }
+
+    private static boolean isEqualCardSet(int[] result) {
+        for (int i = 0; i < cards.length; i++) {
+            if (cards[i] != result[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### ✅ 21315 | [카드 섞기](https://www.acmicpc.net/problem/21315) | 난이도: 골드 5 | 유형: 브루트포스

### 📝 문제 설명
> 브루트포스로 카드 섞기를 구현하는 문제입니다.

### 💡 풀이 설명
- n의 최댓값은 1000이다. 2^k <= n 조건에 의해 k의 최댓값은 9가 된다. 카드 섞기를 두번 진행하므로, 모든 경우의 수를 탐색하면 81회의 케이스를 순회해야 한다. 카드를 한번 섞을때는 k가 최댓값인 9라고 가정해도, 섞기 연산 1회당 횟수 약 1000회 이하이다. 따라서 O(n^2)으로 완전탐색 풀이 가능하다.
---

### ✅ 15661 | [링크와 스타트](https://www.acmicpc.net/problem/15661) | 난이도: 골드 5 | 유형: 브루트포스, 백트래킹(조합)

### 📝 문제 설명
> 팀을 2개로 나누는 모든 조합을 찾고, 능력치 차이의 최솟값을 찾는 문제입니다.

### 💡 풀이 설명
- 팀을 두개로 나누는 모든 경우의 수는 nC1부터 nC(n/2)까지의 합이다. 따라서 O(2^n)이고, 각각의 경우에 전체 멤버를 순회하며 값을 계산하는 연산은 O(n^2)이다. n <= 20이므로 완전탐색으로 풀이 가능하다.
---

### ✅ 14500 | [테트로미노](https://www.acmicpc.net/problem/14500) | 난이도: 골드 4 | 유형: 브루트포스, 그래프탐색

### 📝 문제 설명
> 상하좌우로 인접한 4칸짜리 테트로미노의 모든 경우를 순회하면서 최댓값을 찾는 문제입니다.

### 💡 풀이 설명
- n은 최대 500이므로, 원소는 총 250,000개이다. 테트로미노가 완성 될 때까지 원소 하나를 고르고, 인접한 4개 중 다시 하나를 고른다. 이때 원소 하나를 고를때마다, 인접한 변은 최대 3개까지 늘어난다. 따라서, 최악의 경우의 연산 횟수는 250000 * 4 * (4 + 3) * (4 + 3 + 3)이므로, 완전탐색으로 풀이 가능하다.
---

### ✅ 21278 | [호석이 두마리 치킨](https://www.acmicpc.net/problem/21278) | 난이도: 골드 4 | 유형: 최단거리 탐색, 브루트포스
### 📝 문제 설명
> 우선 모든 노드간의 최단거리를 구합니다. 그리고 가능한 모든 조합에 대해 치킨집을 세울 거리의 최솟값을 계산합니다.

### 💡 풀이 설명
- 노드의 갯수가 최대 100개이고, 간선은 5000개 미만입니다. O(n^2)으로 최단거리와 조합 연산 모두 가능하므로 완전탐색입니다.
- 하지만 이 문제는.. 완탐이 문제가 아니라 제가 최단거리 탐색 알고리즘에 오개념이 있었습니다ㅠㅠ 더 공부해야겠네요..
---