### PR TITLE
[ADD] k0000k 12주차

### DIFF
--- a/algorithms/binary_search/k0000k/Bj1477.java
+++ b/algorithms/binary_search/k0000k/Bj1477.java
@@ -1,0 +1,73 @@
+package binary_search.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj1477 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static int[] diff; // diff[i]는 i번째, i-1번째 휴게소 사이 거리
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int l = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] spots = new int[n + 2];
+        for (int i = 1; i < n + 1; i++) {
+            spots[i] = Integer.parseInt(st.nextToken());
+        }
+        spots[n + 1] = l;
+
+        Arrays.sort(spots);
+
+        diff = new int[n + 1];
+        for (int i = 1; i < spots.length; i++) {
+            diff[i - 1] = spots[i] - spots[i - 1];
+        }
+
+        Arrays.sort(diff);
+
+        int left = l / (n + m + 1); // 가능한 최솟값은 모든 휴게소간 거리가 같을 때
+        int right = findMax(diff); // 가능한 최댓값은 현재 상태에서의 최대거리
+        int mid = (left + right) / 2;
+        while (left <= right) {
+            if (possibleMax(mid, m)) {
+                right = mid - 1;
+            }
+            else {
+                left = mid + 1;
+            }
+            mid = (left + right) / 2;
+        }
+        System.out.println(mid + 1);
+    }
+
+    private static boolean possibleMax(int val, int m) {
+        // m번 이하로 쪼개서 diff의 최댓값이 val이 되도록 만들수있는지?
+        int cnt = 0;
+        for (Integer num : diff) {
+            while (num > val) {
+                num -= val;
+                cnt++;
+            }
+            if (cnt > m) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 최댓값 찾기
+    private static int findMax(int[] arr) {
+        int result = 0;
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i] > result) {
+                result = arr[i];
+            }
+        }
+        return result;
+    }
+}

--- a/algorithms/binary_search/k0000k/Bj20444.java
+++ b/algorithms/binary_search/k0000k/Bj20444.java
@@ -1,0 +1,35 @@
+package binary_search.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+public class Bj20444 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        long n = Long.parseLong(st.nextToken());
+        long k = Long.parseLong(st.nextToken());
+
+        // n = a + b 일때, (a + 1) * (b + 1) = k
+        long left = 0;
+        long right = n / 2;
+        long mid = (left + right) / 2;
+        while (left <= right) {
+            long val = (mid + 1) * (n - mid + 1);
+            if (val == k) {
+                System.out.println("YES");
+                return;
+            }
+            else if (val > k) {
+                right = mid - 1;
+            }
+            else {
+                left = mid + 1;
+            }
+            mid = (left + right) / 2;
+        }
+        System.out.println("NO");
+    }
+}

--- a/algorithms/binary_search/k0000k/Bj2470.java
+++ b/algorithms/binary_search/k0000k/Bj2470.java
@@ -1,0 +1,55 @@
+package binary_search.k0000k;
+
+import java.io.*;
+import java.util.*;
+
+class Liquid implements Comparable<Liquid> {
+    int val;
+    int abs;
+
+    public Liquid(int val) {
+        this.val = val;
+        this.abs = Math.abs(val);
+    }
+
+    @Override
+    public int compareTo(Liquid o) { // 절댓값 기준으로 정렬
+        if (this.abs == o.abs) {
+            return this.val - o.val;
+        }
+        return this.abs - o.abs;
+    }
+}
+
+public class Bj2470 {
+
+    public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static Liquid[] liquids;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        liquids = new Liquid[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            liquids[i] = new Liquid(Integer.parseInt(st.nextToken()));
+        }
+
+        // 절댓값이 가장 가까운 값을 더한것만 최솟값의 후보가 된다.
+        Arrays.sort(liquids);
+
+        int min = Integer.MAX_VALUE;
+        int idx = -1;
+        for (int i = 0; i < n - 1; i++) { // 인접한 값만 확인한다.
+            int sum = Math.abs(liquids[i].val + liquids[i + 1].val);
+            if (sum < min) {
+                min = sum;
+                idx = i;
+            }
+        }
+
+        int val1 = liquids[idx].val;
+        int val2 = liquids[idx + 1].val;
+
+        System.out.println(Math.min(val1, val2) + " " + Math.max(val1, val2));
+    }
+}


### PR DESCRIPTION
### ✅ 2470 | [두 용액](https://www.acmicpc.net/problem/2470) | 난이도: 골드 5 | 유형: 정렬, 그리디?

### 📝 문제 설명
> 가장 절댓값이 가까운 용액을 더한 경우만 정답의 후보가 됩니다. 그 중 최소를 찾습니다.

### 💡 풀이 설명
- 왜 이분탐색인지 모르겠습니다ㅠ
- 절댓값 작은 순으로 정렬합니다. 그러면 절대값이 가장 인접한 데이터끼리의 합만 비교하면 됩니다.
---

### ✅ 20444 | [색종이와 가위](https://www.acmicpc.net/problem/20444) | 난이도: 골드 5 | 유형: 이분탐색

### 📝 문제 설명
> 시간제한이 0.01초입니다. 이분탐색을 활용하여 정확히 k를 만족하는 케이스가 있는지 찾습니다.

### 💡 풀이 설명
- 이 문제에서 n은 int 범위이고, k는 long입니다. 하지만 n을 int로 잡으면 중간값을 계산하는 과정에서 오버플로우가 발생합니다. 이걸 못잡아서 시간이 오래 걸린 문제입니다 😢 이럴땐 그냥 맘편하게 둘다 long으로 잡는게 가장 안전한것 같습니다!
---

### ✅ 1477 | [휴게소 세우기](https://www.acmicpc.net/problem/1477) | 난이도: 골드 4 | 유형: 이분탐색

### 📝 문제 설명
> 이분탐색으로 조건을 만족하는 최솟값을 찾습니다.

### 💡 풀이 설명
- 최댓값의 최소 또는 최솟값의 최대는 굉장히 유명한 이분탐색 유형입니다. 분명 그건 아는데.. 역시 알고리즘은 오래 쉬면 안되겠군요. 구현 아이디어 떠올리는데 한참 걸렸습니다. 
- 이분탐색으로 임의의 mid 값이 최댓값이 될수있는지를 탐색하면 됩니다.
---