### PR TITLE
[ADD] GainLee 12주차

### DIFF
--- a/algorithms/binary_search/GainLee/Boj_1477.java
+++ b/algorithms/binary_search/GainLee/Boj_1477.java
@@ -1,0 +1,54 @@
+package binary_search.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_1477 {
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n; static int m; static int length;
+    static int[] rest_spot;
+
+    static boolean isRestSpot(int mid) {
+        int cnt = 0;
+        for (int i = 1; i < n+1; i++) {
+            int gap = rest_spot[i] - rest_spot[i-1];
+            cnt += (gap-1) / mid;
+        }
+        if (cnt > m) return true;
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        length = Integer.parseInt(st.nextToken());
+        rest_spot = new int[n + 2];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i < n; i++) {
+            rest_spot[i] = Integer.parseInt(st.nextToken());
+        }
+        rest_spot[0] = 0;
+        rest_spot[n+1] = length;
+
+        Arrays.sort(rest_spot);
+
+        int left = 0;
+        int right = length;
+
+        while (left <= right) {
+            int mid = (left + right) / 2;
+
+            if (isRestSpot(mid)) {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        } // while
+
+        System.out.println(left);
+
+    } // main
+}

--- a/algorithms/binary_search/GainLee/Boj_20444.java
+++ b/algorithms/binary_search/GainLee/Boj_20444.java
@@ -1,0 +1,43 @@
+package binary_search.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_20444 {
+    // 색종이 자르기
+    // 조각의 수 = (세로로 자른 횟수 + 1) + (가로로 자른 횟수 + 1)
+    static long cut(long row, long col) {
+        return (row + 1) * (col + 1);
+    } // cut
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        ArrayList<int[]> arr = new ArrayList<>();
+
+        int n = Integer.parseInt(st.nextToken()); // 가위질
+        long k = Long.parseLong(st.nextToken()); // 종이 조각
+
+        long left = 0;
+        long right = n / 2;
+
+        while (left <= right) {
+            long row = (left + right) / 2;
+            long col = n - row;
+
+            long total = cut(row, col);
+            if (total == k) {
+                System.out.println("YES");
+                return;
+            } else if (total > k) {
+                // row 와 col의 차이가 커야함.
+                right = row - 1;
+            } else if (total < k) {
+                left = row + 1;
+            }
+        }
+        System.out.println("NO");
+
+    } // main
+
+}

--- a/algorithms/binary_search/GainLee/Boj_2110.java
+++ b/algorithms/binary_search/GainLee/Boj_2110.java
@@ -1,0 +1,62 @@
+package binary_search.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class  Boj_2110 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n; static int c;
+    static ArrayList<Integer> map = new ArrayList<>();
+
+
+    static int canInstall(int distance) {
+        int count = 1;
+        int lastlocate = map.get(0);
+
+        for (int i = 0; i < map.size(); i++) {
+            int locate = map.get(i);
+
+            // 현재 탐색하는 점의 위치와 직전에 설치했던 집의 위치간 거리가
+            // 최소 거리(distance) 보다 크거나 같을 때 공유기 설치 개수를 늘려주고
+            // 마지막 설치 위치를 갱신해준다.
+            if (locate - lastlocate >= distance) {
+                count++;
+                lastlocate = locate;
+            }
+        }
+
+        return count;
+    } // canInstall
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        for (int i = 0; i < n; i++) {
+            map.add(Integer.parseInt(br.readLine()));
+        }
+
+        Collections.sort(map);
+
+        int low = 1;
+        int high = map.get(n-1) - map.get(0) + 1;
+
+        while (low < high) {
+            int mid = (low + high) / 2;
+
+            if (canInstall(mid) < c) {
+                high = mid;
+            } else  {
+                low = mid + 1;
+            }
+
+        }
+        // upper bound는 탐색값을 초과하는 첫 번째 값을 가리키므로,
+        // 1을 빼준 값이 조건식을 만족하는 최대값이 된다.
+        System.out.println(low -1);
+
+
+    } // main
+}
+

--- a/algorithms/binary_search/GainLee/Boj_2470.java
+++ b/algorithms/binary_search/GainLee/Boj_2470.java
@@ -1,0 +1,46 @@
+package binary_search.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_2470 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static long[] arr;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        arr = new long[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Long.parseLong(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+
+        // 투 포인터
+        long min_sum = Long.MAX_VALUE;
+        int left = 0;
+        int right = n-1;
+        int min_left = 0;
+        int min_right = 0;
+        while (left < right) {
+            long sum = arr[left] + arr[right];
+            if (Math.abs(sum) < min_sum) {
+                min_sum = Math.abs(sum);
+                min_left = left;
+                min_right = right;
+            }
+
+            if (sum >= 0) {
+                right--;
+            } else {
+                left++;
+            }
+        }
+
+        System.out.println(arr[min_left] + " " + arr[min_right]);
+
+    } // main
+
+}

--- a/algorithms/binary_search/GainLee/Boj_2473.java
+++ b/algorithms/binary_search/GainLee/Boj_2473.java
@@ -1,0 +1,49 @@
+package binary_search.GainLee;
+
+import java.io.*;
+import java.util.*;
+
+public class Boj_2473 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static long[] arr;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        arr = new long[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Long.parseLong(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+
+        // 투 포인터
+        long min_sum = Long.MAX_VALUE;
+        int min_left = 0;
+        int min_right = 0;
+        int min_mid = 0;
+        for (int i = 0; i < n - 2; i++) {
+            int left = i + 1;
+            int right = n - 1;
+
+            while (left < right) {
+                long sum = arr[left] + arr[i] + arr[right];
+                if (Math.abs(sum) < min_sum) {
+                    min_sum = Math.abs(sum);
+                    min_left = i;
+                    min_mid = left;
+                    min_right = right;
+                }
+                if (sum >= 0) {
+                    right--;
+                } else {
+                    left++;
+                }
+            } // while
+        } // for
+
+        System.out.println(arr[min_left] + " " + arr[min_mid] + " " + arr[min_right]);
+
+    } // main
+}


### PR DESCRIPTION
### ✅ 2470 | [두 용액](https://www.acmicpc.net/problem/2470) | 난이도: Gold V | 유형: 이분탐색, 투포인터

### 📝 문제 설명
> 용액을 섞었을때(더했을때) 0과 가장 가까운 수가 되는 두 용액을 구하는 문제입니다.

### 💡 풀이 설명
- 이번주 유형은 이분탐색이지만, 이 문제를 봤을때 투포인터로 푸는 것이 더 쉽겠다고 생각해 투포인터로 풀었습니다.

---

### ✅ 20444 | [색종이와 가위](https://www.acmicpc.net/problem/20444) | 난이도: Gold V | 유형: 이분탐색

### 📝 문제 설명
> 색종이를 잘라 주어진 조각을 만들 수 있는지 확인하는 문제입니다.

### 💡 풀이 설명
- 조각의 수는 (세로로 자른 횟수 + 1) * (가로로 자른 횟수 + 1) 입니다.
- 조각의 수가 목표 수와 다르면 자른 횟수를 더하거나 빼는 방식으로 문제를 풀었습니다.

---

### ✅ 1477 | [휴게소 세우기](https://www.acmicpc.net/problem/1477) | 난이도: Gold IV | 유형: 이분탐색

### 📝 문제 설명
> 고속도로에 휴게소를 세우되, 휴게소가 없는 구간의 최대값을 최소로 만드는 문제입니다.

### 💡 풀이 설명
- 마지막 휴게소 지점과 직전 휴게소 지점의 거리를 휴게소 간격으로 나눈 뒤 cnt 에 더합니다.
- 만약 휴게소 개수보다 많다면 True를 반환해 left 를 옮깁니다.
- 아니라면 False를 반환해 right를 옮깁니다.
---

### ✅ 2110 | [공유기 설치](https://www.acmicpc.net/problem/2110) | 난이도: Gold IV | 유형: 이분탐색

### 📝 문제 설명
> 가장 인접한 두 공유기 사이의 거리를 최대로 설치하는 문제입니다.

### 💡 풀이 설명
- 현재 탐색하는 점의 위치와 직전에 설치했던 집의 위치간 거리가 최소 거리(distance) 보다 크거나 같을 때
- 공유기 설치 개수를 늘려주고 마지막 설치 위치를 갱신해줍니다.

---

### ✅ 2473 | [세 용액](https://www.acmicpc.net/problem/2473) | 난이도: Gold III | 유형: 투포인터
### 📝 문제 설명
> 세용액을 섞었을때 0 과 가장 인접한 수를 만드는 용액을 구하는 문제입니다.

### 💡 풀이 설명
- 두 수를 설정하고, 나머지 한 수는 for문을 통해 모든 수를 탐색했습니다.
- 지금 확인해보니 변수명을 헷갈리게 썼네요..
